### PR TITLE
Added support for external links in project posts and richtexts

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -2,11 +2,13 @@
 	import type { KeyTextField, LinkField } from '@prismicio/client';
 	import { PrismicLink } from '@prismicio/svelte';
 
-    import IconArrow from '~icons/ic/round-arrow-outward'
+	import IconArrow from '~icons/ic/round-arrow-outward';
+	import IconGithub from '~icons/fa-brands/github';
 
 	export let linkField: LinkField;
 	export let label: KeyTextField;
 	export let showIcon: boolean = true;
+	export let githubIcon: boolean = false;
 	let className: string = '';
 	export { className as class };
 </script>
@@ -19,8 +21,13 @@
 		class={`absolute inset-0 z-0 h-full rounded bg-purple-400 transition-transform duration-300 ease-in-out group-hover:translate-y-0 translate-y-9`}
 	></span>
 
-	<span class="relative flex items-center justify-center gap-2">{label}</span>
-    {#if showIcon}
-        <IconArrow />
-    {/if}
+	{#if showIcon}
+		{#if githubIcon}
+			<IconGithub class="mr-2 z-10" />
+			<span class="relative flex items-center justify-center gap-2">{label}</span>
+		{:else}
+			<span class="relative flex items-center justify-center gap-2">{label}</span>
+			<IconArrow class="z-10"/>
+		{/if}
+	{/if}
 </PrismicLink>

--- a/src/lib/slices/RichText/index.svelte
+++ b/src/lib/slices/RichText/index.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import type { Content } from '@prismicio/client';
+	import Button from '$lib/components/Button.svelte';
+import type { Content } from '@prismicio/client';
 	import { PrismicRichText } from '@prismicio/svelte';
 
 	export let slice: Content.RichTextSlice;
@@ -9,4 +10,8 @@
 	<PrismicRichText
 		field={slice.primary.content}
 	/>
+	{#if slice.primary.button_label && slice.primary.button_link}
+		<Button class='prose prose-sm mx-auto md:mx-0 no-underline' githubIcon={true} linkField={slice.primary.button_link} label={slice.primary.button_label} />
+	{/if}
+	
 </div>

--- a/src/lib/slices/RichText/mocks.json
+++ b/src/lib/slices/RichText/mocks.json
@@ -13,6 +13,18 @@
 						}
 					}
 				]
+			},
+			"button_label": {
+				"__TYPE__": "FieldContent",
+				"value": "practice",
+				"type": "Text"
+			},
+			"button_link": {
+				"__TYPE__": "LinkContent",
+				"value": {
+					"__TYPE__": "ExternalLink",
+					"url": "http://twitter.com"
+				}
 			}
 		},
 		"items": [

--- a/src/lib/slices/RichText/model.json
+++ b/src/lib/slices/RichText/model.json
@@ -22,6 +22,21 @@
               "codespan"
             ]
           }
+        },
+        "button_label": {
+          "type": "Text",
+          "config": {
+            "label": "Button Label",
+            "placeholder": ""
+          }
+        },
+        "button_link": {
+          "type": "Link",
+          "config": {
+            "label": "Button Link",
+            "placeholder": "",
+            "select": null
+          }
         }
       },
       "items": {},

--- a/src/prismicio-types.d.ts
+++ b/src/prismicio-types.d.ts
@@ -801,6 +801,26 @@ export interface RichTextSliceDefaultPrimary {
 	 * - **Documentation**: https://prismic.io/docs/field#rich-text-title
 	 */
 	content: prismic.RichTextField;
+
+	/**
+	 * Button Label field in *RichText → Default → Primary*
+	 *
+	 * - **Field Type**: Text
+	 * - **Placeholder**: *None*
+	 * - **API ID Path**: rich_text.default.primary.button_label
+	 * - **Documentation**: https://prismic.io/docs/field#key-text
+	 */
+	button_label: prismic.KeyTextField;
+
+	/**
+	 * Button Link field in *RichText → Default → Primary*
+	 *
+	 * - **Field Type**: Link
+	 * - **Placeholder**: *None*
+	 * - **API ID Path**: rich_text.default.primary.button_link
+	 * - **Documentation**: https://prismic.io/docs/field#link-content-relationship
+	 */
+	button_link: prismic.LinkField;
 }
 
 /**


### PR DESCRIPTION
Added support for rendering a button in project posts in case an external link was to be added. Now a button with a link can be rendered after any piece of rich text, with an extra option to use GitHub icon for GitHub links.